### PR TITLE
Update IDLImporter.dll to .NET Standard 2.0

### DIFF
--- a/IDLImporter/IDLImporter.csproj
+++ b/IDLImporter/IDLImporter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>SIL.IdlImporterTool</RootNamespace>
     <AssemblyTitle>IDLImporter</AssemblyTitle>
     <Configurations>Debug;Release</Configurations>


### PR DESCRIPTION
Changed IDLImporter target framework from 4.6.1 to .NET Standard 2.0 to allow it to also be built for other frameworks like .NET Core.