### PR TITLE
Migration to dot net6

### DIFF
--- a/IDLImporter/IDLConversions.cs
+++ b/IDLImporter/IDLConversions.cs
@@ -322,6 +322,12 @@ namespace SIL.IdlImporterTool
 					"Can't call COM method marked with [local] attribute in IDL file"))));
 				attributes.Remove("local");
 			}
+			if (attributes["restricted"] != null)
+			{
+				member.CustomAttributes.Add(new CodeAttributeDeclaration("TypeLibFunc",
+					new CodeAttributeArgument(new CodeSnippetExpression("TypeLibFuncFlags.FRestricted"))));
+				attributes.Remove("restricted");
+			}
 			if (attributes["warning"] != null)
 			{
 				member.Comments.Add(new CodeCommentStatement(string.Format("<remarks>{0}</remarks>",
@@ -693,6 +699,8 @@ namespace SIL.IdlImporterTool
 			coClass.CustomAttributes.Add(new CodeAttributeDeclaration("ComImport"));
 			coClass.CustomAttributes.Add(new CodeAttributeDeclaration("ClassInterface",
 				new CodeAttributeArgument(new CodeSnippetExpression("ClassInterfaceType.None"))));
+			coClass.CustomAttributes.Add(new CodeAttributeDeclaration("TypeLibType",
+				new CodeAttributeArgument(new CodeSnippetExpression("TypeLibTypeFlags.FCanCreate"))));
 			coClass.BaseTypes.Add(type.BaseTypes[0]);
 			coClass.BaseTypes.Add(new CodeTypeReference(type.Name));
 

--- a/IDLImporter/IDLConversions.cs
+++ b/IDLImporter/IDLConversions.cs
@@ -324,8 +324,6 @@ namespace SIL.IdlImporterTool
 			}
 			if (attributes["restricted"] != null)
 			{
-				member.CustomAttributes.Add(new CodeAttributeDeclaration("TypeLibFunc",
-					new CodeAttributeArgument(new CodeSnippetExpression("TypeLibFuncFlags.FRestricted"))));
 				attributes.Remove("restricted");
 			}
 			if (attributes["warning"] != null)
@@ -699,8 +697,6 @@ namespace SIL.IdlImporterTool
 			coClass.CustomAttributes.Add(new CodeAttributeDeclaration("ComImport"));
 			coClass.CustomAttributes.Add(new CodeAttributeDeclaration("ClassInterface",
 				new CodeAttributeArgument(new CodeSnippetExpression("ClassInterfaceType.None"))));
-			coClass.CustomAttributes.Add(new CodeAttributeDeclaration("TypeLibType",
-				new CodeAttributeArgument(new CodeSnippetExpression("TypeLibTypeFlags.FCanCreate"))));
 			coClass.BaseTypes.Add(type.BaseTypes[0]);
 			coClass.BaseTypes.Add(new CodeTypeReference(type.Name));
 

--- a/IDLImporter/IDLConversions.cs
+++ b/IDLImporter/IDLConversions.cs
@@ -322,12 +322,6 @@ namespace SIL.IdlImporterTool
 					"Can't call COM method marked with [local] attribute in IDL file"))));
 				attributes.Remove("local");
 			}
-			if (attributes["restricted"] != null)
-			{
-				member.CustomAttributes.Add(new CodeAttributeDeclaration("TypeLibFunc",
-					new CodeAttributeArgument(new CodeSnippetExpression("TypeLibFuncFlags.FRestricted"))));
-				attributes.Remove("restricted");
-			}
 			if (attributes["warning"] != null)
 			{
 				member.Comments.Add(new CodeCommentStatement(string.Format("<remarks>{0}</remarks>",
@@ -699,8 +693,6 @@ namespace SIL.IdlImporterTool
 			coClass.CustomAttributes.Add(new CodeAttributeDeclaration("ComImport"));
 			coClass.CustomAttributes.Add(new CodeAttributeDeclaration("ClassInterface",
 				new CodeAttributeArgument(new CodeSnippetExpression("ClassInterfaceType.None"))));
-			coClass.CustomAttributes.Add(new CodeAttributeDeclaration("TypeLibType",
-				new CodeAttributeArgument(new CodeSnippetExpression("TypeLibTypeFlags.FCanCreate"))));
 			coClass.BaseTypes.Add(type.BaseTypes[0]);
 			coClass.BaseTypes.Add(new CodeTypeReference(type.Name));
 

--- a/IDLImporter/IDLImporter.csproj
+++ b/IDLImporter/IDLImporter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>SIL.IdlImporterTool</RootNamespace>
     <AssemblyTitle>IDLImporter</AssemblyTitle>
     <Configurations>Debug;Release</Configurations>


### PR DESCRIPTION
Changed IDLImporter target framework from 4.6.1 to .NET Standard 2.0 and removed TypeLib attribute support in code generation.