### PR TITLE
Fix exception during binary serialization in the move to .NET Standard

### DIFF
--- a/IDLImporter/IDLImporter.cs
+++ b/IDLImporter/IDLImporter.cs
@@ -416,7 +416,7 @@ namespace SIL.IdlImporterTool
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Serializes the data to a file with the same name as the IDL file but with the
-		/// extension ".json" (and ".iip" for backwards compatibility).
+		/// ".json" extension.
 		/// </summary>
 		/// <param name="fileName">Name of the IDL file.</param>
 		/// <param name="cnamespace">The namespace definition with all classes and methods.</param>
@@ -427,52 +427,19 @@ namespace SIL.IdlImporterTool
 				/* Formatting.Indented, */
 				new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
 			File.WriteAllText(Path.ChangeExtension(fileName, "json"), serializedDefinition);
-
-			// For backwards compatibility we additionally use binary serialization
-			using (var outFile = new FileStream(Path.ChangeExtension(fileName, "iip"),
-				FileMode.Create))
-			{
-				var formatter = new BinaryFormatter();
-				try
-				{
-					formatter.Serialize(outFile, cnamespace);
-				}
-				catch (SerializationException e)
-				{
-					Logger.Error($"Failed to serialize to internal data file. Reason: {e.Message}");
-				}
-			}
 		}
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Deserializes the data.
 		/// </summary>
-		/// <param name="fileName">Name of the JSON or IIP file.</param>
+		/// <param name="fileName">Name of the JSON file.</param>
 		/// <returns>The namespace definition with all classes and methods.</returns>
 		/// ------------------------------------------------------------------------------------
 		private CodeNamespace DeserializeData(string fileName)
 		{
 			if (!File.Exists(fileName))
 				return null;
-
-			if (Path.GetExtension(fileName) == "iip")
-			{
-				using (var inFile = new FileStream(fileName, FileMode.Open, FileAccess.Read))
-				{
-					var formatter = new BinaryFormatter();
-					try
-					{
-						var obj = formatter.Deserialize(inFile);
-						return obj as CodeNamespace;
-					}
-					catch (SerializationException e)
-					{
-						Logger.Error($"Failed to deserialize referenced data from file \"{fileName}\". Reason: {e.Message}");
-					}
-				}
-				return null;
-			}
 
 			try
 			{

--- a/IDLImporter/IDLImporter.cs
+++ b/IDLImporter/IDLImporter.cs
@@ -11,7 +11,6 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
-using KGySoft.Serialization.Binary;
 using Newtonsoft.Json;
 
 namespace SIL.IdlImporterTool
@@ -433,8 +432,7 @@ namespace SIL.IdlImporterTool
 			using (var outFile = new FileStream(Path.ChangeExtension(fileName, "iip"),
 				FileMode.Create))
 			{
-				var formatter = new BinaryFormatter
-					{SurrogateSelector = new CustomSerializerSurrogateSelector()};
+				var formatter = new BinaryFormatter();
 				try
 				{
 					formatter.Serialize(outFile, cnamespace);
@@ -462,8 +460,7 @@ namespace SIL.IdlImporterTool
 			{
 				using (var inFile = new FileStream(fileName, FileMode.Open, FileAccess.Read))
 				{
-					var formatter = new BinaryFormatter
-						{SurrogateSelector = new CustomSerializerSurrogateSelector()};
+					var formatter = new BinaryFormatter();
 					try
 					{
 						var obj = formatter.Deserialize(inFile);

--- a/IDLImporter/IDLImporter.cs
+++ b/IDLImporter/IDLImporter.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
+using KGySoft.Serialization.Binary;
 using Newtonsoft.Json;
 
 namespace SIL.IdlImporterTool
@@ -432,7 +433,8 @@ namespace SIL.IdlImporterTool
 			using (var outFile = new FileStream(Path.ChangeExtension(fileName, "iip"),
 				FileMode.Create))
 			{
-				var formatter = new BinaryFormatter();
+				var formatter = new BinaryFormatter
+					{SurrogateSelector = new CustomSerializerSurrogateSelector()};
 				try
 				{
 					formatter.Serialize(outFile, cnamespace);
@@ -460,7 +462,8 @@ namespace SIL.IdlImporterTool
 			{
 				using (var inFile = new FileStream(fileName, FileMode.Open, FileAccess.Read))
 				{
-					var formatter = new BinaryFormatter();
+					var formatter = new BinaryFormatter
+						{SurrogateSelector = new CustomSerializerSurrogateSelector()};
 					try
 					{
 						var obj = formatter.Deserialize(inFile);

--- a/IDLImporter/IDLImporter.csproj
+++ b/IDLImporter/IDLImporter.csproj
@@ -28,12 +28,14 @@ See full changelog at https://github.com/sillsdev/IdlImporter/blob/master/CHANGE
     <ChangelogFile>../CHANGELOG.md</ChangelogFile>
     <NoWarn>1591</NoWarn>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Antlr2.Runtime.Patched" Version="2.7.7" />
     <PackageReference Include="Antlr2.Tools.Patched" Version="2.7.6.5" PrivateAssets="All" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
+    <PackageReference Include="KGySoft.CoreLibraries" Version="6.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/IDLImporter/IDLImporter.csproj
+++ b/IDLImporter/IDLImporter.csproj
@@ -28,14 +28,12 @@ See full changelog at https://github.com/sillsdev/IdlImporter/blob/master/CHANGE
     <ChangelogFile>../CHANGELOG.md</ChangelogFile>
     <NoWarn>1591</NoWarn>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Antlr2.Runtime.Patched" Version="2.7.7" />
     <PackageReference Include="Antlr2.Tools.Patched" Version="2.7.6.5" PrivateAssets="All" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
-    <PackageReference Include="KGySoft.CoreLibraries" Version="6.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/IdlImpTool/IDLImp.cs
+++ b/IdlImpTool/IDLImp.cs
@@ -30,7 +30,7 @@ namespace SIL.IdlImporterTool
 			System.Console.WriteLine("\t/i idhfile\tname of IDH file for comments (Default: none)");
 			System.Console.WriteLine("\t/n namespace\tNamespace of the file to be produced");
 			System.Console.WriteLine("\t/u namespace\tadditional using namespaces");
-			System.Console.WriteLine("\t/r iipfile\tFile name of .iip file to use to resolve references");
+			System.Console.WriteLine("\t/r jsonfile\tFile name of .json file to use to resolve references");
 			System.Console.WriteLine("\t/x (0|1)\t1= create, 0= suppress XML comments (Default: 1)");
 			System.Console.WriteLine("\t/? \t\tshow this help information");
 		}


### PR DESCRIPTION
Previously this step was throwing a SerializationException, because the CodeNamespace class (now in a Nuget package) used in creating .iip files is no longer marked with the [Serializable] attribute, which is required for use with the BinaryFormatter. It should also be noted that this exception is only thrown with a clean output directory (and not subsequent builds), as the code doesn't treat the exception as crashing but generates the needed Kernel.cs file anyway (which skips all this on subsequent builds). Regardless, the solution, in lieu of removing this component altogether, was to add a custom SurrogateSelector (in added package KGySoft.CoreLibraries) to the BinaryFormatter which allows it to serialize even objects not marked with [Serializable]. It should be noted that the output files (.iip and .json) are similar to the original 4.6.1 files but not identical. It should also be carefully noted that .NET is moving, and advising moving, away from the use of BinaryFormatter for security reasons (https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide). With this in mind, it's highly possible that a better solution would in fact be to remove this component and support only the safer JSON serialization already present.

This could fix #17 if we want to maintain binary serialization support