### PR TITLE
Use System.CodeDom 6.0.0 from Nuget

### DIFF
--- a/IDLImporter/IDLImporter.csproj
+++ b/IDLImporter/IDLImporter.csproj
@@ -38,6 +38,7 @@ See full changelog at https://github.com/sillsdev/IdlImporter/blob/master/CHANGE
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="System.CodeDom" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IdlImpTool/IDLImp.csproj
+++ b/IdlImpTool/IDLImp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>SIL.FieldWorks.Tools</RootNamespace>
     <AssemblyTitle>IDLImp</AssemblyTitle>


### PR DESCRIPTION
* Update to get best compatibility with global tool runtimes
* Drop netcoreapp2.1 since it is incompatible with new
  CodeDom package